### PR TITLE
Fix HuggingFace Spaces port constraint for Vawlrathh

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,8 +2,8 @@
 
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from fastapi import FastAPI, Response
-from fastapi.responses import JSONResponse
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
 import psutil
@@ -41,7 +41,7 @@ app = FastAPI(
     title="Arena Improver",
     description="MCP for Magic: The Gathering Arena deck analysis and optimization",
     version=__version__,
-    lifespan=lifespan
+    lifespan=lifespan,
 )
 
 # Add CORS middleware
@@ -58,40 +58,47 @@ app.include_router(router, prefix="/api/v1", tags=["decks"])
 app.include_router(ws_router, prefix="/api/v1", tags=["chat"])
 
 
-# Root endpoint removed - Gradio UI handles the root path when mounted via mount_gradio_app
-# API info is available at /docs (Swagger UI) and /redoc (ReDoc)
+# Root endpoint redirects to Gradio UI for HuggingFace Spaces compatibility
+# The Gradio interface is mounted at /gradio for clean separation from FastAPI routes
+# API information available at:
+#   - /api - API service info
+#   - /docs - Interactive Swagger UI documentation
+#   - /redoc - ReDoc API documentation
 
 
 @app.get("/", include_in_schema=False)
-async def deprecated_root():
+async def root():
+    """Redirect root path to Gradio UI.
+    
+    HuggingFace Spaces and users expect the root path to be accessible.
+    This redirects to the Gradio interface mounted at /gradio.
     """
-    Deprecated root endpoint.
-    This endpoint has moved to /api. This is a breaking change as of version 2.0.0.
-    """
-    return JSONResponse(
-        status_code=410,
-        content={
-            "detail": "The root endpoint `/` has been removed. Please use `/api` for API information.",
-            "new_endpoint": "/api",
-            "deprecation": "This is a breaking change as of version 2.0.0. See CHANGELOG.md for details."
-        }
-    )
+    return RedirectResponse(url="/gradio")
+
+
 @app.get("/api")
 async def api_info():
-    """API information endpoint."""
+    """API information and available endpoints.
+
+    This endpoint provides information about the Arena Improver API service.
+    For full interactive documentation, visit /docs or /redoc.
+    The Gradio UI is available at /gradio.
+    """
     return {
         "service": "Arena Improver",
         "version": __version__,
         "description": "MCP for MTG Arena deck analysis",
+        "ui": "/gradio",
         "docs": "/docs",
+        "redoc": "/redoc",
         "mcp_server": "Use mcp_server.py for MCP protocol access",
         "chat": "WebSocket chat at /api/v1/ws/chat/{client_id}",
         "features": [
             "Deck analysis & optimization",
             "Physical card purchase links",
             "Real-time chat with Vawlrathh, The Small'n",
-            "AI consensus checking"
-        ]
+            "AI consensus checking",
+        ],
     }
 
 
@@ -104,7 +111,7 @@ async def health_check():
     return {
         "status": "healthy",
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "version": __version__
+        "version": __version__,
     }
 
 
@@ -121,31 +128,23 @@ async def readiness_check():
         return {
             "status": "ready",
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "checks": {
-                "database": "connected"
-            }
+            "checks": {"database": "connected"},
         }
     except SQLAlchemyError as e:
         # Log the actual error for debugging
         logger.error(f"Database initialization failed: {e}", exc_info=True)
-        
+
         return JSONResponse(
-            content={
-                "status": "not_ready",
-                "error": "Database initialization failed"
-            },
-            status_code=503
+            content={"status": "not_ready", "error": "Database initialization failed"},
+            status_code=503,
         )
     except Exception as e:
         # Log unexpected errors for debugging
         logger.error(f"Unexpected readiness check failure: {e}", exc_info=True)
-        
+
         return JSONResponse(
-            content={
-                "status": "not_ready",
-                "error": "Service initialization failed"
-            },
-            status_code=503
+            content={"status": "not_ready", "error": "Service initialization failed"},
+            status_code=503,
         )
 
 
@@ -155,10 +154,7 @@ async def liveness_check():
 
     Returns 200 if process is alive (for restart decisions).
     """
-    return {
-        "status": "alive",
-        "timestamp": datetime.now(timezone.utc).isoformat()
-    }
+    return {"status": "alive", "timestamp": datetime.now(timezone.utc).isoformat()}
 
 
 @app.get("/metrics")
@@ -193,7 +189,7 @@ async def metrics():
                 "hit_rate": round(meta_stats["hit_rate"], 3),
                 "hits": meta_stats["hits"],
                 "misses": meta_stats["misses"],
-                "utilization": round(meta_stats["utilization"], 3)
+                "utilization": round(meta_stats["utilization"], 3),
             },
             "deck": {
                 "size": deck_stats["size"],
@@ -201,9 +197,9 @@ async def metrics():
                 "hit_rate": round(deck_stats["hit_rate"], 3),
                 "hits": deck_stats["hits"],
                 "misses": deck_stats["misses"],
-                "utilization": round(deck_stats["utilization"], 3)
-            }
-        }
+                "utilization": round(deck_stats["utilization"], 3),
+            },
+        },
     }
 
 
@@ -217,7 +213,7 @@ async def status():
     env_status = {
         "OPENAI_API_KEY": "configured" if os.getenv("OPENAI_API_KEY") else "missing",
         "TAVILY_API_KEY": "configured" if os.getenv("TAVILY_API_KEY") else "missing",
-        "EXA_API_KEY": "configured" if os.getenv("EXA_API_KEY") else "missing"
+        "EXA_API_KEY": "configured" if os.getenv("EXA_API_KEY") else "missing",
     }
 
     # Get cache stats
@@ -234,26 +230,22 @@ async def status():
             "database": "connected",
             "cache": {
                 "meta": f"{meta_cache.stats()['size']}/{meta_cache.stats()['max_size']} entries",
-                "deck": f"{deck_cache.stats()['size']}/{deck_cache.stats()['max_size']} entries"
-            }
+                "deck": f"{deck_cache.stats()['size']}/{deck_cache.stats()['max_size']} entries",
+            },
         },
         "features": {
             "deck_analysis": True,
             "ai_optimization": env_status["OPENAI_API_KEY"] == "configured",
             "meta_intelligence": env_status["TAVILY_API_KEY"] == "configured",
-            "semantic_search": env_status["EXA_API_KEY"] == "configured"
-        }
+            "semantic_search": env_status["EXA_API_KEY"] == "configured",
+        },
     }
 
 
 if __name__ == "__main__":
     import os
+
     # Note: 0.0.0.0 binds to all interfaces for Docker/production use
     # Use 127.0.0.1 for local development to restrict access
     host = os.getenv("API_HOST", "127.0.0.1")
-    uvicorn.run(
-        "src.main:app",
-        host=host,
-        port=8000,
-        reload=True
-    )
+    uvicorn.run("src.main:app", host=host, port=8000, reload=True)


### PR DESCRIPTION
HuggingFace Spaces only exposes port 7860 publicly. The previous architecture ran FastAPI on 7860 and Gradio on 7861, making the Gradio UI inaccessible on HF Spaces.

Changes:
- Use mount_gradio_app to consolidate both services on port 7860
- Remove subprocess-based FastAPI server startup
- Import FastAPI app directly and mount Gradio at root path
- Update API documentation iframe to use /docs directly
- Move FastAPI root endpoint to /api to avoid conflict with Gradio

This ensures both the API endpoints (/api/v1/*, /docs, /health) and the Gradio UI (/) are accessible on HF Spaces.

# Pull Request

## Description

<!-- Provide a clear and concise description of the changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build configuration change
- [ ] 🔒 Security fix

## Related Issues

<!-- Link related issues using keywords: Fixes #123, Closes #456, Related to #789 -->

Fixes #
Related to #

## Changes Made

<!-- List the specific changes made in this PR -->

-
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests passing locally
- [ ] Coverage maintained/improved (>80%)

### Manual Testing

<!-- Describe manual testing performed -->

```bash
# Commands used for testing
```

**Test Results:**
-
-

## Screenshots / Examples

<!-- If applicable, add screenshots or code examples to demonstrate the changes -->

```python
# Code examples
```

## Checklist

<!-- Mark completed items with an 'x' -->

### Code Quality

- [ ] My code follows the project's style guidelines (PEP 8, Ruff)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added type hints to new functions/methods

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

### Security

- [ ] I have checked for security vulnerabilities (SQL injection, XSS, etc.)
- [ ] No sensitive data (API keys, passwords) is hardcoded
- [ ] Input validation is properly implemented
- [ ] I have run security scanners (bandit, pip-audit)

### Documentation

- [ ] I have updated the README.md (if needed)
- [ ] I have updated CHANGELOG.md
- [ ] I have added/updated docstrings
- [ ] API documentation is updated (if applicable)

### Dependencies

- [ ] I have not introduced new dependencies unnecessarily
- [ ] New dependencies are pinned to specific versions
- [ ] I have updated requirements.txt / pyproject.toml
- [ ] Dependencies pass security audit (pip-audit)

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here -->

**Before:**
```python
# Old behavior
```

**After:**
```python
# New behavior
```

**Migration Guide:**
1.
2.
3.

## Performance Impact

<!-- Describe any performance implications -->

- [ ] No performance impact
- [ ] Performance improved
- [ ] Performance may be affected (explain below)

**Details:**

## Database Changes

<!-- If applicable, describe database schema changes -->

- [ ] No database changes
- [ ] New tables/columns added
- [ ] Migration script provided
- [ ] Backwards compatible

## Deployment Notes

<!-- Special instructions for deploying this change -->

**Pre-deployment:**
-

**Post-deployment:**
-

## Rollback Plan

<!-- How to rollback if issues are discovered -->

1.
2.

---

## 🤖 Claude AI Review

<!-- Claude will automatically review this PR when it's created or updated -->

Want a focused review on specific aspects? Tag @claude with a comment:

- `@claude please review` - Full code review
- `@claude check for security issues` - Security-focused review
- `@claude suggest optimizations` - Performance review
- `@claude review test coverage` - Testing review

See [CLAUDE.md](../CLAUDE.md) for more information.

---

## Additional Notes

<!-- Any additional information that reviewers should know -->

---

**Reviewer Guidelines:**

- Check code quality and adherence to standards
- Verify test coverage is adequate
- Look for potential security issues
- Consider performance implications
- Ensure documentation is clear and complete
- Test the changes locally if possible


Summary of Changes:

This pull request refactors the deployment approach for the Hugging Face Space by unifying the FastAPI and Gradio services into a single application running on one port. The main improvements include consolidating the servers, simplifying deployment, and updating the routing and documentation to reflect these changes.

**Deployment and server architecture:**
- Combined FastAPI and Gradio into a single application using Gradio's `mount_gradio_app`, so both services now run on port 7860, eliminating the need for separate processes and ports. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L3-R5) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L15-R44) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R652-R696)

**Code and configuration cleanup:**
- Removed all code related to starting, stopping, and health-checking a separate FastAPI server process (such as `kill_existing_uvicorn`, `start_fastapi_server`, and `wait_for_fastapi_ready`). [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L368-L449) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R652-R696)
- Updated environment variables and internal URLs to reflect the single-port setup for both HTTP and WebSocket connections.

**User interface and documentation:**
- Updated the API documentation links in the Gradio interface to point directly to `/docs` since both FastAPI and Gradio are now served from the same port.
- Removed the FastAPI root endpoint (previously `/`), as the Gradio UI now handles the root path; added a new `/api` endpoint to provide API information.